### PR TITLE
refactor:add secount sort order if order by count result

### DIFF
--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -45,7 +45,7 @@ const adminController = {
           [sequelize.literal('(SELECT COUNT(*) FROM Followships WHERE Followships.followingId = User.id)'), 'followerCount'],
           [sequelize.literal('(SELECT COUNT(*) FROM Tweets JOIN Likes on Tweets.id = Likes.TweetId WHERE Tweets.UserId = User.id)'), 'tweetsLikedCount']
         ],
-        order: [[sequelize.literal('tweetsCount'), 'DESC']],
+        order: [[sequelize.literal('tweetsCount'), 'DESC'], ['name', 'ASC']],
         nest: true,
         raw: true
       })

--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -251,7 +251,7 @@ const userController = {
           [sequelize.literal('(SELECT COUNT(*) FROM Followships WHERE Followships.followingId = User.id)'), 'followerCount'],
           [sequelize.literal(`(SELECT (COUNT(*) > 0) FROM Followships WHERE Followships.followerId = ${loginUserId} AND Followships.followingId = User.id)`), 'isFollowed']
         ],
-        order: [[sequelize.literal('followerCount'), 'DESC']],
+        order: [[sequelize.literal('followerCount'), 'DESC'], ['name', 'ASC']],
         limit: 10,
         raw: true,
         nest: true

--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -1,6 +1,7 @@
 const bcrypt = require('bcryptjs')
 const dayjs = require('dayjs')
 const jwt = require('jsonwebtoken')
+const { Op } = require('sequelize')
 
 const helpers = require('../_helpers')
 const { User, Reply, Tweet, Like, Followship, sequelize } = require('../models')
@@ -251,6 +252,11 @@ const userController = {
           [sequelize.literal('(SELECT COUNT(*) FROM Followships WHERE Followships.followingId = User.id)'), 'followerCount'],
           [sequelize.literal(`(SELECT (COUNT(*) > 0) FROM Followships WHERE Followships.followerId = ${loginUserId} AND Followships.followingId = User.id)`), 'isFollowed']
         ],
+        where: {
+          role: {
+            [Op.ne]: 'admin'
+          }
+        },
         order: [[sequelize.literal('followerCount'), 'DESC'], ['name', 'ASC']],
         limit: 10,
         raw: true,


### PR DESCRIPTION
如果排序是依據count的結果，有可能會有luigi同名次的，追加第二排序: order by name
因為有其他同學發現沒有指定第二台排序的話，get top 10 users有同樣追蹤者人數的(同名次)，排序會不固定
例如:
mario和luigi追隨者人數都100人，在列表顯示時，有時會是mario在前面，有時會是luigi在前面

因此增加第二排序，讓同名次的項目，順序不會亂跳

調整的controller:
前台gettopUser, 後台(admin)的getUsers