### PR TITLE
refactor: remove getTopUsers limit

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -258,7 +258,6 @@ const userController = {
           }
         },
         order: [[sequelize.literal('followerCount'), 'DESC'], ['name', 'ASC']],
-        limit: 10,
         raw: true,
         nest: true
       })


### PR DESCRIPTION
跟前端討論取消推薦追蹤名單的取資料筆數限制
本來限制10筆，改成全部拉出來
讓前端用陣列篩選(因前端未來可能優化可以按鈕看更多推薦追蹤名單)