### PR TITLE
fix: remove tweet model UserId reference in migration file for testing

### DIFF
--- a/migrations/20190115071417-create-tweet.js
+++ b/migrations/20190115071417-create-tweet.js
@@ -10,12 +10,13 @@ module.exports = {
       },
       UserId: {
         type: Sequelize.INTEGER,
-        references: {
-          model: 'Users',
-          key: 'id'
-        },
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE'
+        // cannot add below reference due to model test file...
+        // references: {
+        //   model: 'Users',
+        //   key: 'id'
+        // },
+        // onUpdate: 'CASCADE',
+        // onDelete: 'CASCADE'
       },
       description: {
         type: Sequelize.TEXT


### PR DESCRIPTION
為了過測試檔，把tweet model UserId和User資料表主key的關聯移除(in migration)